### PR TITLE
Added --mackerel_metric_key_prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Display how to use.
                 --max_child_limit       Number to be used for limiting pidstat multi processes (default:30) (skip this limit if 0 is specified)
                 --mackerel_api_key      An api key to be used for posting to mackerel
                 --mackerel_service_name An mackerel service name
+                --mackerel_metric_key_prefix  Key prefix of mackerel metric name (default:batch_)
               Requirement Programs: pidstat and pstree commands
 
 # LICENSE

--- a/README.md
+++ b/README.md
@@ -91,16 +91,16 @@ Display how to use.
             linux-get-pidstat - command description
               Usage: command [options]
               Options:
-                --pid_dir               A directory path for pid files
-                --res_file              A file path to be stored results
-                --interval              Interval second to be given as a pidstat argument (default:1)
-                --count                 Count number to be given as a pidstat argument (default:60)
-                --dry_run               Dry run mode. not run the side-effects operation (default:1) (--no-dry_run is also supported)
-                --datetime              Datetime (ex. '2016-06-10 00:00:00') to be recorded
-                --include_child         Flag to be enabled to include child process metrics (default:1) (--no-include_child is also suppoted)
-                --max_child_limit       Number to be used for limiting pidstat multi processes (default:30) (skip this limit if 0 is specified)
-                --mackerel_api_key      An api key to be used for posting to mackerel
-                --mackerel_service_name An mackerel service name
+                --pid_dir                     A directory path for pid files
+                --res_file                    A file path to be stored results
+                --interval                    Interval second to be given as a pidstat argument (default:1)
+                --count                       Count number to be given as a pidstat argument (default:60)
+                --dry_run                     Dry run mode. not run the side-effects operation (default:1) (--no-dry_run is also supported)
+                --datetime                    Datetime (ex. '2016-06-10 00:00:00') to be recorded
+                --include_child               Flag to be enabled to include child process metrics (default:1) (--no-include_child is also suppoted)
+                --max_child_limit             Number to be used for limiting pidstat multi processes (default:30) (skip this limit if 0 is specified)
+                --mackerel_api_key            An api key to be used for posting to mackerel
+                --mackerel_service_name       An mackerel service name
                 --mackerel_metric_key_prefix  Key prefix of mackerel metric name (default:batch_)
               Requirement Programs: pidstat and pstree commands
 

--- a/lib/Linux/GetPidstat.pm
+++ b/lib/Linux/GetPidstat.pm
@@ -61,12 +61,12 @@ sub run {
     }
 
     Linux::GetPidstat::Writer->new(
-        res_file              => $args{res_file},
-        mackerel_api_key      => $args{mackerel_api_key},
-        mackerel_service_name => $args{mackerel_service_name},
+        res_file                   => $args{res_file},
+        mackerel_api_key           => $args{mackerel_api_key},
+        mackerel_service_name      => $args{mackerel_service_name},
         mackerel_metric_key_prefix => $args{mackerel_metric_key_prefix},
-        now                   => $datetime,
-        dry_run               => $args{dry_run},
+        now                        => $datetime,
+        dry_run                    => $args{dry_run},
     )->output($ret_pidstats);
 }
 
@@ -171,16 +171,16 @@ Display how to use.
             linux-get-pidstat - command description
               Usage: command [options]
               Options:
-                --pid_dir               A directory path for pid files
-                --res_file              A file path to be stored results
-                --interval              Interval second to be given as a pidstat argument (default:1)
-                --count                 Count number to be given as a pidstat argument (default:60)
-                --dry_run               Dry run mode. not run the side-effects operation (default:1) (--no-dry_run is also supported)
-                --datetime              Datetime (ex. '2016-06-10 00:00:00') to be recorded
-                --include_child         Flag to be enabled to include child process metrics (default:1) (--no-include_child is also suppoted)
-                --max_child_limit       Number to be used for limiting pidstat multi processes (default:30) (skip this limit if 0 is specified)
-                --mackerel_api_key      An api key to be used for posting to mackerel
-                --mackerel_service_name An mackerel service name
+                --pid_dir                     A directory path for pid files
+                --res_file                    A file path to be stored results
+                --interval                    Interval second to be given as a pidstat argument (default:1)
+                --count                       Count number to be given as a pidstat argument (default:60)
+                --dry_run                     Dry run mode. not run the side-effects operation (default:1) (--no-dry_run is also supported)
+                --datetime                    Datetime (ex. '2016-06-10 00:00:00') to be recorded
+                --include_child               Flag to be enabled to include child process metrics (default:1) (--no-include_child is also suppoted)
+                --max_child_limit             Number to be used for limiting pidstat multi processes (default:30) (skip this limit if 0 is specified)
+                --mackerel_api_key            An api key to be used for posting to mackerel
+                --mackerel_service_name       An mackerel service name
                 --mackerel_metric_key_prefix  Key prefix of mackerel metric name (default:batch_)
               Requirement Programs: pidstat and pstree commands
 

--- a/lib/Linux/GetPidstat.pm
+++ b/lib/Linux/GetPidstat.pm
@@ -64,6 +64,7 @@ sub run {
         res_file              => $args{res_file},
         mackerel_api_key      => $args{mackerel_api_key},
         mackerel_service_name => $args{mackerel_service_name},
+        mackerel_metric_key_prefix => $args{mackerel_metric_key_prefix},
         now                   => $datetime,
         dry_run               => $args{dry_run},
     )->output($ret_pidstats);
@@ -180,6 +181,7 @@ Display how to use.
                 --max_child_limit       Number to be used for limiting pidstat multi processes (default:30) (skip this limit if 0 is specified)
                 --mackerel_api_key      An api key to be used for posting to mackerel
                 --mackerel_service_name An mackerel service name
+                --mackerel_metric_key_prefix  Key prefix of mackerel metric name (default:batch_)
               Requirement Programs: pidstat and pstree commands
 
 =head1 LICENSE

--- a/lib/Linux/GetPidstat/Writer.pm
+++ b/lib/Linux/GetPidstat/Writer.pm
@@ -29,6 +29,7 @@ sub output {
         $mackerel = Linux::GetPidstat::Writer::Mackerel->new(
             mackerel_api_key      => $self->{mackerel_api_key},
             mackerel_service_name => $self->{mackerel_service_name},
+            mackerel_metric_key_prefix => $self->{mackerel_metric_key_prefix},
             now                   => $self->{now},
             dry_run               => $self->{dry_run},
         );

--- a/lib/Linux/GetPidstat/Writer.pm
+++ b/lib/Linux/GetPidstat/Writer.pm
@@ -27,11 +27,11 @@ sub output {
     my $mackerel;
     if (length $self->{mackerel_api_key} && length $self->{mackerel_service_name}) {
         $mackerel = Linux::GetPidstat::Writer::Mackerel->new(
-            mackerel_api_key      => $self->{mackerel_api_key},
-            mackerel_service_name => $self->{mackerel_service_name},
+            mackerel_api_key           => $self->{mackerel_api_key},
+            mackerel_service_name      => $self->{mackerel_service_name},
             mackerel_metric_key_prefix => $self->{mackerel_metric_key_prefix},
-            now                   => $self->{now},
-            dry_run               => $self->{dry_run},
+            now                        => $self->{now},
+            dry_run                    => $self->{dry_run},
         );
     }
 

--- a/lib/Linux/GetPidstat/Writer/Mackerel.pm
+++ b/lib/Linux/GetPidstat/Writer/Mackerel.pm
@@ -16,7 +16,7 @@ sub new {
         service_name => $opt{mackerel_service_name},
     );
     $opt{mackerel} = $mackerel;
-    $opt{mackerel_metric_key_prefix} //= "";
+    $opt{mackerel_metric_key_prefix} = "" unless defined $opt{mackerel_metric_key_prefix};
 
     bless \%opt, $class;
 }

--- a/lib/Linux/GetPidstat/Writer/Mackerel.pm
+++ b/lib/Linux/GetPidstat/Writer/Mackerel.pm
@@ -16,13 +16,14 @@ sub new {
         service_name => $opt{mackerel_service_name},
     );
     $opt{mackerel} = $mackerel;
+    $opt{mackerel_metric_key_prefix} //= "";
 
     bless \%opt, $class;
 }
 
 sub output {
     my ($self, $program_name, $metric_name, $metric) = @_;
-    my $graph_name = "custom.batch_$metric_name.$program_name";
+    my $graph_name = sprintf("custom.%s%s.%s", $self->{mackerel_metric_key_prefix}, $metric_name, $program_name);
 
     if ($self->{dry_run}) {
         printf "(dry_run) mackerel post: name=%s, time=%s, metric=%s\n",

--- a/script/linux-get-pidstat
+++ b/script/linux-get-pidstat
@@ -18,6 +18,7 @@ my %opt = (
     interval        => 1,
     count           => 60,
     dry_run         => 1,
+    mackerel_metric_key_prefix => 'batch_',
 );
 GetOptions(
     \%opt, qw/
@@ -31,6 +32,7 @@ GetOptions(
       max_child_limit|l=i
       mackerel_api_key|m=s
       mackerel_service_name|s=s
+      mackerel_metric_key_prefix=s
       /
 ) or pod2usage(2);
 
@@ -58,4 +60,5 @@ linux-get-pidstat - cli tool for Linux::GetPidstat
         --max_child_limit       Number to be used for limiting pidstat multi processes (default:30) (skip this limit if 0 is specified)
         --mackerel_api_key      An api key to be used for posting to mackerel
         --mackerel_service_name An mackerel service name
+        --mackerel_metric_key_prefix  Key prefix of mackerel metric name (default:batch_)
       Requirement Programs: pidstat and pstree commands

--- a/script/linux-get-pidstat
+++ b/script/linux-get-pidstat
@@ -50,15 +50,15 @@ linux-get-pidstat - cli tool for Linux::GetPidstat
     linux-get-pidstat - command description
       Usage: command [options]
       Options:
-        --pid_dir               A directory path for pid files
-        --res_file              A file path to be stored results
-        --interval              Interval second to be given as a pidstat argument (default:1)
-        --count                 Count number to be given as a pidstat argument (default:60)
-        --dry_run               Dry run mode. not run the side-effects operation (default:1) (--no-dry_run is also supported)
-        --datetime              Datetime (ex. '2016-06-10 00:00:00') to be recorded
-        --include_child         Flag to be enabled to include child process metrics (default:1) (--no-include_child is also suppoted)
-        --max_child_limit       Number to be used for limiting pidstat multi processes (default:30) (skip this limit if 0 is specified)
-        --mackerel_api_key      An api key to be used for posting to mackerel
-        --mackerel_service_name An mackerel service name
+        --pid_dir                     A directory path for pid files
+        --res_file                    A file path to be stored results
+        --interval                    Interval second to be given as a pidstat argument (default:1)
+        --count                       Count number to be given as a pidstat argument (default:60)
+        --dry_run                     Dry run mode. not run the side-effects operation (default:1) (--no-dry_run is also supported)
+        --datetime                    Datetime (ex. '2016-06-10 00:00:00') to be recorded
+        --include_child               Flag to be enabled to include child process metrics (default:1) (--no-include_child is also suppoted)
+        --max_child_limit             Number to be used for limiting pidstat multi processes (default:30) (skip this limit if 0 is specified)
+        --mackerel_api_key            An api key to be used for posting to mackerel
+        --mackerel_service_name       An mackerel service name
         --mackerel_metric_key_prefix  Key prefix of mackerel metric name (default:batch_)
       Requirement Programs: pidstat and pstree commands

--- a/t/02_basic.t
+++ b/t/02_basic.t
@@ -125,8 +125,9 @@ subtest 'output to a file (dry_run=1)' => sub {
 my $output_mkr  = get_data_section('output.mkr');
 my @output_mkr_lines = split '\n', $output_mkr;
 
-$cli_default_opt{mackerel_api_key}      = 'dummy_key';
-$cli_default_opt{mackerel_service_name} = 'dummy_name';
+$cli_default_opt{mackerel_api_key}           = 'dummy_key';
+$cli_default_opt{mackerel_service_name}      = 'dummy_name';
+$cli_default_opt{mackerel_metric_key_prefix} = 'batch_';
 subtest 'output to a file and mackerel' => sub {
     $instance->run(%cli_default_opt);
 

--- a/t/04_writer.t
+++ b/t/04_writer.t
@@ -126,8 +126,9 @@ subtest 'output to a file (dry_run=1)' => sub {
     $opt{dry_run} = 0;
 };
 
-$opt{mackerel_api_key}      = 'dummy_key';
-$opt{mackerel_service_name} = 'dummy_name';
+$opt{mackerel_api_key}           = 'dummy_key';
+$opt{mackerel_service_name}      = 'dummy_name';
+$opt{mackerel_metric_key_prefix} = 'batch_';
 
 my $output_mkr  = get_data_section('output.mkr');
 my @output_mkr_lines = split '\n', $output_mkr;


### PR DESCRIPTION
I added `--mackerel_metric_key_prefix` option because I want to change prefix of mackerel metric name from `batch_` .