### PR TITLE
Fixed: Use of uninitialized value  in numeric eq (==) at /path/to/Linux/GetPidstat/Reader.pm line 27.

### DIFF
--- a/lib/Linux/GetPidstat/Reader.pm
+++ b/lib/Linux/GetPidstat/Reader.pm
@@ -24,7 +24,7 @@ sub get_program_pid_mapping {
 
         my $pid = $pid_file->slurp;
         # Skip processing if it could not read anything from the file
-        next if length($pid) == 0;
+        next unless length($pid);
 
         chomp($pid);
         unless (_is_valid_pid($pid)) {


### PR DESCRIPTION
ref. https://github.com/yoheimuta/Linux-GetPidstat/pull/9